### PR TITLE
Fix: Undo previous score throws does not work as expected

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "gulp-karma": "0.0.4",
     "gulp-minify-css": "^0.4.3",
     "gulp-rename": "^1.2.0",
-    "gulp-sass": "^1.3.2",
+    "gulp-sass": "^2.3.2",
     "jasmine-core": "^2.1.3",
     "karma": "^0.12.31",
     "karma-chrome-launcher": "^0.1.7",

--- a/src/app/directives/moveInfo.js
+++ b/src/app/directives/moveInfo.js
@@ -5,7 +5,7 @@ angular.module('darts').directive('moveInfo', [
     return {
       restrict : 'A',
       replace: true,
-      template: '<span class="move-info">{{move}}</span>',
+      template: '<span class="move-info">{{move.points}}</span>',
       scope: {
         move: "=moveInfo"
       }

--- a/src/app/services/players.js
+++ b/src/app/services/players.js
@@ -29,8 +29,10 @@ var Player = function(name, email) {
 
   this.undoLastMove = function() {
     if (moves.length > 0) {
-      var lastMove = parseInt(moves.pop());
-      score += lastMove;
+      var lastMove = moves.pop();
+      if (lastMove.persisted) {
+        score += parseInt(lastMove.points);
+      }
     }
   };
 
@@ -46,11 +48,13 @@ var Player = function(name, email) {
     }
 
     if (isWholeNumber(points) && points >= 0) {
-      moves.push(points);
+      var move = { points: points, persisted: false };
 
       if (points <= score) {
+        move.persisted = true;
         score -= points;
       }
+      moves.push(move);
     }
   };
 

--- a/tests/services/players.spec.js
+++ b/tests/services/players.spec.js
@@ -112,7 +112,7 @@ describe('players', function() {
     player.makeMove(25);
 
     var moves = player.getMoves();
-    expect(moves[moves.length-1]).toEqual(25);
+    expect(moves[moves.length-1].points).toEqual(25);
   });
 
   it('should only make a move if the move is a non negative number', function() {
@@ -129,14 +129,14 @@ describe('players', function() {
 
     moves = player.getMoves();
     expect(moves.length).toEqual(1);
-    expect(moves[moves.length-1]).toEqual(25);
+    expect(moves[moves.length-1].points).toEqual(25);
 
     player.makeMove('x');
     expect(player.score()).toEqual(276);
 
     moves = player.getMoves();
     expect(moves.length).toEqual(1);
-    expect(moves[moves.length-1]).toEqual(25);
+    expect(moves[moves.length-1].points).toEqual(25);
 
 
     player.makeMove(1.2);
@@ -144,7 +144,7 @@ describe('players', function() {
 
     moves = player.getMoves();
     expect(moves.length).toEqual(1);
-    expect(moves[moves.length-1]).toEqual(25);
+    expect(moves[moves.length-1].points).toEqual(25);
   });
 
   it('should make a move with more points than the users score', function() {
@@ -154,7 +154,7 @@ describe('players', function() {
     expect(player.score()).toEqual(301);
 
     var moves = player.getMoves();
-    expect(moves[moves.length-1]).toEqual(302);
+    expect(moves[moves.length-1].points).toEqual(302);
   });
 
   it('should reset players score and clear all moves', function() {
@@ -178,7 +178,7 @@ describe('players', function() {
     expect(player.score()).toEqual(201);
 
     var moves = player.getMoves();
-    expect(moves[moves.length-1]).toEqual(100);
+    expect(moves[moves.length-1].points).toEqual(100);
 
     player.undoLastMove();
     expect(player.score()).toEqual(301);
@@ -187,4 +187,22 @@ describe('players', function() {
     expect(moves.length).toEqual(0);
   });
 
+  it('should undo last invalid move', function() {
+    var player = players.createPlayer('Peter');
+    player.score(301);
+    player.makeMove(302);
+
+    expect(player.score()).toEqual(301);
+
+    var moves = player.getMoves();
+    console.log(moves);
+    expect(moves[moves.length-1].points).toEqual(302);
+    expect(moves[moves.length-1].persisted).toEqual(false);
+
+    player.undoLastMove();
+    expect(player.score()).toEqual(301);
+
+    moves = player.getMoves();
+    expect(moves.length).toEqual(0);
+  });
 });


### PR DESCRIPTION
Issue #1:
Updated gulp-sass.
Added persisted flag to moves.